### PR TITLE
Supply --user flag when invoking start-stop-daemon in debian

### DIFF
--- a/debs/Debian/debian/rabbitmq-server.init
+++ b/debs/Debian/debian/rabbitmq-server.init
@@ -69,7 +69,7 @@ start_rabbitmq () {
         ensure_pid_dir
         set +e
         RABBITMQ_PID_FILE=$PID_FILE start-stop-daemon --quiet \
-            --chuid rabbitmq --start \
+            --chuid $USER --user $USER --start \
             --pidfile "$PID_FILE" --background \
             --startas /bin/sh -- -c "exec $DAEMON >'${RABBITMQ_SERVER_CONSOLE_OUTPUT_DIR}/startup_log' 2>'${RABBITMQ_SERVER_CONSOLE_OUTPUT_DIR}/startup_err'"
         $CONTROL wait --timeout $RABBITMQ_STARTUP_TIMEOUT $PID_FILE >/dev/null 2>&1


### PR DESCRIPTION
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=921557 for context.

Per discussion with @dumbbell.