### PR TITLE
Debian: drop dh-systemd build dependency

### DIFF
--- a/debs/Debian/debian/control
+++ b/debs/Debian/debian/control
@@ -6,7 +6,6 @@ Uploaders: Michael Klishin <michael@rabbitmq.com>,
  Karl Nilsson <knilsson@rabbitmq.com>,
  Jean-Sébastien Pédron <jean-sebastien@rabbitmq.com>
 Build-Depends: debhelper (>= 9),
- dh-systemd (>= 1.5),
  erlang-base (>= 1:23.3) | erlang-base-hipe (>= 1:23.3) | esl-erlang (>= 1:23.3),
  erlang-base (<< 1:24.0) | erlang-base-hipe (<< 1:24.0) | esl-erlang (<< 1:24.0),
  erlang-crypto (>= 1:23.3) | esl-erlang (>= 1:23.3),


### PR DESCRIPTION
dh-systemd has been folded into debhelper
in Debian 9.2 [1][2], and in Bullseye,
dh-systemd no longer exists.

1. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=958585
2. https://alioth-lists-archive.debian.net/pipermail/debhelper-devel/2016-July/003714.html