### PR TITLE
Removes socat dependency from specs

### DIFF
--- a/RPMS/Fedora/rabbitmq-server.spec
+++ b/RPMS/Fedora/rabbitmq-server.spec
@@ -22,7 +22,7 @@ BuildRequires:  systemd
 %endif
 
 Requires: erlang >= %{erlang_minver}
-Requires: logrotate, socat
+Requires: logrotate
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-%{_arch}-root
 Summary: The RabbitMQ server
 

--- a/debs/Debian/debian/control
+++ b/debs/Debian/debian/control
@@ -81,8 +81,7 @@ Depends: init-system-helpers (>= 1.13~),
  erlang-xmerl (>= 1:23.2) | esl-erlang (>= 1:23.2),
  erlang-xmerl (<< 1:25.0) | esl-erlang (<< 1:25.0),
  adduser,
- logrotate,
- socat
+ logrotate
 Description: Multi-protocol messaging broker
  RabbitMQ is an open source multi-protocol messaging broker.
 Homepage: https://www.rabbitmq.com/


### PR DESCRIPTION
Reverting the spec changes from rabbitmq/rabbitmq-server#666.

Since rabbitmq/rabbitmq-server#2957 was merged, it should be safe to not depend on `socat` being installed.

Closes #8.