### PR TITLE
Windows: Fix the value of `$ERLANG_HOME` environment variable

### DIFF
--- a/windows-exe/rabbitmq_nsi.in
+++ b/windows-exe/rabbitmq_nsi.in
@@ -471,12 +471,12 @@ Function findErlang
     ${EndIf}
 
     ; See https://nsis.sourceforge.io/Setting_Environment_Variables
-    WriteRegExpandStr ${env_hklm} ERLANG_HOME $0
+    WriteRegExpandStr ${env_hklm} ERLANG_HOME $erlang_otp_dir
     SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
 
     ; On Windows XP changing the permanent environment does not change *our*
     ; environment, so do that as well.
-    System::Call 'Kernel32::SetEnvironmentVariableA(t, t) i("ERLANG_HOME", "$0").r0'
+    System::Call 'Kernel32::SetEnvironmentVariableA(t, t) i("ERLANG_HOME", "$erlang_otp_dir").r0'
   ${EndIf}
 
 FunctionEnd


### PR DESCRIPTION
The value was set from a register set after reading the Erlang install path from the Registry.

However, as part of #22, I rewrote how we detect the version of Erlang. While doing this, I used regular variables instead of registers to improve the readability and make sure the code doesn't break because a future change overwrites a register.

This is exactly what happened here: I didn't see the `$0` register was used later in the same function. In #22, I stored the Erlang install path in a variable and used the register for temporary storage in several loops. At the time we want to set `$ERLANG_HOME`, the register holds a file descriptor integer which is meaningless.

As a consequence, the RabbitMQ service fails to be installed and started as part of the installer process. After the install, RabbitMQ CLI tools fail to run. All because `$ERLANG_HOME` is incorrectly set.

This patch uses the `$erlang_otp_dir` variable to correctly set `$ERLANG_HOME`. This should be future-proof this time.