### PR TITLE
Debian: bump Elixir (a build time dep) to 1.13.4+

### DIFF
--- a/debs/Debian/debian/control
+++ b/debs/Debian/debian/control
@@ -25,7 +25,7 @@ Build-Depends: debhelper (>= 9),
  erlang-xmerl (>= 1:25.0) | esl-erlang (>= 1:25.0),
  erlang-dev (>= 1:25.0) | esl-erlang (>= 1:25.0),
  erlang-src (>= 1:25.0) | esl-erlang (>= 1:25.0),
- elixir (>= 1.12.3),
+ elixir (>= 1.13.4),
  zip,
  rsync
 Standards-Version: 3.9.6


### PR DESCRIPTION
Both Debian and Ubuntu are hopelessly behind, with Ubuntu 22.10 shipping Elixir 1.12.2, which is older than the previous requirement of 1.12.3.

So this would not really change much for those building RabbitMQ from source, and we build Elixir 1.13.4 ourselves at the moment, so might as well use it.