### PR TITLE
Do not require user interaction in silent mode; Add error return codes

### DIFF
--- a/windows-exe/rabbitmq_nsi.in
+++ b/windows-exe/rabbitmq_nsi.in
@@ -179,7 +179,9 @@ Section "RabbitMQ Service" RabbitService
   ExecDos::exec /DETAILED '"$INSTDIR\rabbitmq_server-%%VERSION%%\sbin\rabbitmq-service.bat" install' ""
   Pop $0 # return value
   ${If} $0 <> 0
-    MessageBox MB_OK "rabbitmq-service.bat install exited with code $0."
+    ${IfNot} ${Silent}
+      MessageBox MB_OK "rabbitmq-service.bat install exited with code $0."
+    ${EndIf}
     Abort
   ${EndIf}
   ReadEnvStr $1 "HOMEDRIVE"
@@ -447,7 +449,9 @@ Function findErlang
     IfErrors otp_version_error compare_otp_versions
 
     otp_version_error:
-    MessageBox MB_OK|MB_ICONEXCLAMATION "Failed to read the version of Erlang/OTP from file $erlang_otp_version_file"
+    ${IfNot} ${Silent}
+      MessageBox MB_OK|MB_ICONEXCLAMATION "Failed to read the version of Erlang/OTP from file $erlang_otp_version_file"
+    ${EndIf}
     Abort
 
     compare_otp_versions:
@@ -460,14 +464,18 @@ Function findErlang
 
     ${VersionCompare} $erlang_otp_version ${ERLANG_MIN_VERSION} $3
     ${If} $3 = 2
-      MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too old. Please install a more recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
+      ${IfNot} ${Silent}
+        MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too old. Please install a more recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
+      ${EndIf}
       Abort
     ${EndIf}
 
     ${If} "${ERLANG_MAX_VERSION}" != ""
       ${VersionCompare} $erlang_otp_version "${ERLANG_MAX_VERSION}" $3
       ${If} $3 <> 2
-        MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too new. Please install a less recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
+        ${IfNot} ${Silent}
+          MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too new. Please install a less recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
+        ${EndIf}
         Abort
       ${EndIf}
     ${EndIf}
@@ -487,7 +495,9 @@ Function FinishPage.Run
   ExecDos::exec '"$INSTDIR\rabbitmq_server-%%VERSION%%\sbin\rabbitmq-service.bat" start' ""
   Pop $0 # return value
   ${If} $0 <> 0
-    MessageBox MB_OK "rabbitmq-service.bat start exited with code $0."
+    ${IfNot} ${Silent}
+      MessageBox MB_OK "rabbitmq-service.bat start exited with code $0."
+    ${EndIf}
     Abort
   ${EndIf}
 FunctionEnd

--- a/windows-exe/rabbitmq_nsi.in
+++ b/windows-exe/rabbitmq_nsi.in
@@ -182,7 +182,8 @@ Section "RabbitMQ Service" RabbitService
     ${IfNot} ${Silent}
       MessageBox MB_OK "rabbitmq-service.bat install exited with code $0."
     ${EndIf}
-    Abort
+	SetErrorLevel 11
+	Abort
   ${EndIf}
   ReadEnvStr $1 "HOMEDRIVE"
   ReadEnvStr $2 "HOMEPATH"
@@ -426,6 +427,7 @@ Function findErlang
 		ExecShell "open" "https://www.erlang.org/downloads"
 	${EndIf}
 	abort:
+	SetErrorLevel 21
 	Abort
   ${Else}
     Var /GLOBAL erlang_otp_dir
@@ -455,7 +457,8 @@ Function findErlang
     ${IfNot} ${Silent}
       MessageBox MB_OK|MB_ICONEXCLAMATION "Failed to read the version of Erlang/OTP from file $erlang_otp_version_file"
     ${EndIf}
-    Abort
+	SetErrorLevel 22
+	Abort
 
     compare_otp_versions:
     FileRead $1 $erlang_otp_version
@@ -470,7 +473,8 @@ Function findErlang
       ${IfNot} ${Silent}
         MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too old. Please install a more recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
       ${EndIf}
-      Abort
+	  SetErrorLevel 23
+	  Abort
     ${EndIf}
 
     ${If} "${ERLANG_MAX_VERSION}" != ""
@@ -479,7 +483,8 @@ Function findErlang
         ${IfNot} ${Silent}
           MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too new. Please install a less recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
         ${EndIf}
-        Abort
+		SetErrorLevel 24
+		Abort
       ${EndIf}
     ${EndIf}
 
@@ -501,7 +506,8 @@ Function FinishPage.Run
     ${IfNot} ${Silent}
       MessageBox MB_OK "rabbitmq-service.bat start exited with code $0."
     ${EndIf}
-    Abort
+	SetErrorLevel 11
+	Abort
   ${EndIf}
 FunctionEnd
 

--- a/windows-exe/rabbitmq_nsi.in
+++ b/windows-exe/rabbitmq_nsi.in
@@ -182,8 +182,8 @@ Section "RabbitMQ Service" RabbitService
     ${IfNot} ${Silent}
       MessageBox MB_OK "rabbitmq-service.bat install exited with code $0."
     ${EndIf}
-	SetErrorLevel 11
-	Abort
+      SetErrorLevel 11
+      Abort
   ${EndIf}
   ReadEnvStr $1 "HOMEDRIVE"
   ReadEnvStr $2 "HOMEPATH"
@@ -316,11 +316,11 @@ Function .onInit
 
   ReadRegStr $0 HKLM ${uninstall} "UninstallString"
   ${If} $0 != ""
-	${IfNot} ${Silent}
-		MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "RabbitMQ is already installed. $\n$\nClick 'OK' to remove the previous version or 'Cancel' to cancel this installation." /SD IDOK IDOK rununinstall IDCANCEL norun
-		norun:
-		Abort
-	${EndIf}
+    ${IfNot} ${Silent}
+      MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "RabbitMQ is already installed. $\n$\nClick 'OK' to remove the previous version or 'Cancel' to cancel this installation." /SD IDOK IDOK rununinstall IDCANCEL norun
+      norun:
+      Abort
+    ${EndIf}
 
     rununinstall:
     ;Run the uninstaller
@@ -422,13 +422,13 @@ Function findErlang
   ${Loop}
 
   ${If} $2 = "not-found"
-   ${IfNot} ${Silent}
-		MessageBox MB_YESNO|MB_ICONEXCLAMATION "Erlang could not be detected.$\nYou must install Erlang before installing RabbitMQ. Would you like the installer to open a browser window to the Erlang download site?" IDNO abort
-		ExecShell "open" "https://www.erlang.org/downloads"
-	${EndIf}
-	abort:
-	SetErrorLevel 21
-	Abort
+    ${IfNot} ${Silent}
+      MessageBox MB_YESNO|MB_ICONEXCLAMATION "Erlang could not be detected.$\nYou must install Erlang before installing RabbitMQ. Would you like the installer to open a browser window to the Erlang download site?" IDNO abort
+      ExecShell "open" "https://www.erlang.org/downloads"
+    ${EndIf}
+    abort:
+    SetErrorLevel 21
+    Abort
   ${Else}
     Var /GLOBAL erlang_otp_dir
     Var /GLOBAL erlang_otp_version_file
@@ -455,10 +455,10 @@ Function findErlang
 
     otp_version_error:
     ${IfNot} ${Silent}
-      MessageBox MB_OK|MB_ICONEXCLAMATION "Failed to read the version of Erlang/OTP from file $erlang_otp_version_file"
+     MessageBox MB_OK|MB_ICONEXCLAMATION "Failed to read the version of Erlang/OTP from file $erlang_otp_version_file"
     ${EndIf}
-	SetErrorLevel 22
-	Abort
+     SetErrorLevel 22
+     Abort
 
     compare_otp_versions:
     FileRead $1 $erlang_otp_version
@@ -473,8 +473,8 @@ Function findErlang
       ${IfNot} ${Silent}
         MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too old. Please install a more recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
       ${EndIf}
-	  SetErrorLevel 23
-	  Abort
+        SetErrorLevel 23
+        Abort
     ${EndIf}
 
     ${If} "${ERLANG_MAX_VERSION}" != ""
@@ -483,8 +483,8 @@ Function findErlang
         ${IfNot} ${Silent}
           MessageBox MB_OK|MB_ICONEXCLAMATION "Your installed version of Erlang ($erlang_otp_version) is too new. Please install a less recent version [${ERLANG_MIN_VERSION},${ERLANG_MAX_VERSION})."
         ${EndIf}
-		SetErrorLevel 24
-		Abort
+        SetErrorLevel 24
+        Abort
       ${EndIf}
     ${EndIf}
 
@@ -506,8 +506,8 @@ Function FinishPage.Run
     ${IfNot} ${Silent}
       MessageBox MB_OK "rabbitmq-service.bat start exited with code $0."
     ${EndIf}
-	SetErrorLevel 11
-	Abort
+      SetErrorLevel 11
+      Abort
   ${EndIf}
 FunctionEnd
 

--- a/windows-exe/rabbitmq_nsi.in
+++ b/windows-exe/rabbitmq_nsi.in
@@ -315,10 +315,11 @@ Function .onInit
 
   ReadRegStr $0 HKLM ${uninstall} "UninstallString"
   ${If} $0 != ""
-    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "RabbitMQ is already installed. $\n$\nClick 'OK' to remove the previous version or 'Cancel' to cancel this installation." /SD IDOK IDOK rununinstall IDCANCEL norun
-
-    norun:
-    Abort
+	${IfNot} ${Silent}
+		MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "RabbitMQ is already installed. $\n$\nClick 'OK' to remove the previous version or 'Cancel' to cancel this installation." /SD IDOK IDOK rununinstall IDCANCEL norun
+		norun:
+		Abort
+	${EndIf}
 
     rununinstall:
     ;Run the uninstaller
@@ -420,10 +421,12 @@ Function findErlang
   ${Loop}
 
   ${If} $2 = "not-found"
-    MessageBox MB_YESNO|MB_ICONEXCLAMATION "Erlang could not be detected.$\nYou must install Erlang before installing RabbitMQ. Would you like the installer to open a browser window to the Erlang download site?" IDNO abort
-    ExecShell "open" "https://www.erlang.org/downloads"
-    abort:
-    Abort
+   ${IfNot} ${Silent}
+		MessageBox MB_YESNO|MB_ICONEXCLAMATION "Erlang could not be detected.$\nYou must install Erlang before installing RabbitMQ. Would you like the installer to open a browser window to the Erlang download site?" IDNO abort
+		ExecShell "open" "https://www.erlang.org/downloads"
+	${EndIf}
+	abort:
+	Abort
   ${Else}
     Var /GLOBAL erlang_otp_dir
     Var /GLOBAL erlang_otp_version_file


### PR DESCRIPTION
### Description:

Currently, the installer shows message boxes when errors occur, even in silent mode, which requires user interaction. Additionally, it always returns a `0` exit code regardless of any errors.

To address this, the installer now only shows message boxes if run in non-silent mode. In silent mode, errors will be logged without requiring user intervention.

Additionally, to enhance error diagnostics, new exit codes have been introduced. This is open for discussion, and the following are the proposed error codes:

#### **Command Issues:**
- **`1x`**: Issues with commands
  - **`11`**: `rabbitmq-service.bat install` exited with a non-zero code.

#### **Erlang Issues:**
- **`2x`**: Issues related to Erlang.
  - **`21`**: Erlang could not be detected. Erlang must be installed before RabbitMQ.
  - **`22`**: Failed to read Erlang/OTP version from file `$erlang_otp_version_file`.
  - **`23`**: Erlang version `$erlang_otp_version` is too old. Please install a version within the range `[${ERLANG_MIN_VERSION}, ${ERLANG_MAX_VERSION})`.
  - **`24`**: Erlang version `$erlang_otp_version` is too new. Please install a version within the range `[${ERLANG_MIN_VERSION}, ${ERLANG_MAX_VERSION})`.

These new exit codes will provide better error diagnostics, especially when running the installer in silent mode.

**Note:** Code changes were made on lines 319-323 to improve the clarity and understanding of the logic for developers. The default behavior has not changed:
- In the GUI, if RabbitMQ is already installed, the user is prompted to either remove the previous version or cancel the installation.
- In silent mode, the default action is to automatically remove the previous version.

This resolves [#13845](https://github.com/rabbitmq/rabbitmq-server/discussions/13845).