### PR TITLE
Ensure that `tar` sets file modified time correctly

### DIFF
--- a/debs/Debian/Makefile
+++ b/debs/Debian/Makefile
@@ -74,7 +74,7 @@ endif
 	cp -a "$(SOURCE_DIST_FILE)" "$(DEBIAN_ORIG_TARBALL)"
 # Prepare the source directory: we extract the source archive and copy
 # the debian/ subdirectory.
-	xzcat "$(DEBIAN_ORIG_TARBALL)" | tar -xf -
+	tar --touch --xz --extract --file $(DEBIAN_ORIG_TARBALL)
 	cp -a debian "$(UNPACKED_DIR)/debian"
 ifeq ($(INSTALL_BUILD_DEPS),yes)
 # Install build dependencies. To help us, we use mk-build-deps(1) from

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -37,7 +37,7 @@ dist:
 	@elixir --version
 	@echo '--------------------------------------------------'
 	@echo
-	xzcat $(SOURCE_DIST_FILE) | tar -xf -
+	tar --touch --xz --extract --file $(SOURCE_DIST_FILE)
 
 # We explicitely set $HOME as a Make variable below because some package
 # builders do that, as part of cleaning the build environment. It


### PR DESCRIPTION
For some reason, when the source dist archive is built, the file modified times can be in the future. By adding the `--touch` argument, all files have their modified time set to the extraction time. This prevents the "infinite loop make" behavior described in rabbitmq/rabbitmq-server#14440

These changes also update the arguments passed to `tar` to use full arguments that are easier to understand, as well as removes the need for the `xzcat` command, as all build enviroments should have `xz` support built into GNU `tar`.